### PR TITLE
➕ qt 6.8.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
             qt-modules: 'qtcharts qtdatavis3d qtvirtualkeyboard qtwebengine qtquick3d qt3d qt5compat qtimageformats qtmultimedia qtwebview qtserialport qtshadertools qtquicktimeline qtwebsockets qtwebchannel qtpositioning'
           - qt-version: '6.7.3'
             qt-modules: 'qtcharts qtdatavis3d qtvirtualkeyboard qtwebengine qtquick3d qt3d qt5compat qtimageformats qtmultimedia qtwebview qtserialport qtshadertools qtquicktimeline qtwebsockets qtwebchannel qtpositioning'
+          - qt-version: '6.8.2'
+            qt-modules: 'qtcharts qtdatavis3d qtvirtualkeyboard qtwebengine qtquick3d qt3d qt5compat qtimageformats qtmultimedia qtwebview qtserialport qtshadertools qtquicktimeline qtwebsockets qtwebchannel qtpositioning'
     steps:
       -
         name: ⬇ Check out the repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        qt-version: ['5.15.2', '6.6.2', '6.7.3']
+        qt-version: ['5.15.2', '6.6.2', '6.7.3', '6.8.2']
         include:
           - qt-version: '5.15.2'
             qt-modules: 'qtcharts qtdatavis3d qtvirtualkeyboard qtwebengine qtquick3d'


### PR DESCRIPTION
Of course docker being docker, when it's been a while it's not the same system anymore, so aqt wasn't compatible anymore with the python version in ubuntu 20.
Easy workaround is to create an intermediate build step on ubuntu 24 to install aqt (venv mandatory in ubuntu 24, system wide installation is forbidden). Then this download the qt version we want.
The main build step copy the folder from the intermediary build step