### PR TITLE
⬆️ ubuntu 22.04 for Qt 6.10 support (glibc)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,16 +9,8 @@ jobs:
 
     strategy:
       matrix:
-        qt-version: ['5.15.2', '6.6.2', '6.7.3', '6.8.3', '6.9.1', '6.10.1']
+        qt-version: ['6.9.1', '6.10.1']
         include:
-          - qt-version: '5.15.2'
-            qt-modules: 'qtcharts qtdatavis3d qtvirtualkeyboard qtwebengine qtquick3d'
-          - qt-version: '6.6.2'
-            qt-modules: 'qtcharts qtdatavis3d qtvirtualkeyboard qtwebengine qtquick3d qt3d qt5compat qtimageformats qtmultimedia qtwebview qtserialport qtshadertools qtquicktimeline qtwebsockets qtwebchannel qtpositioning'
-          - qt-version: '6.7.3'
-            qt-modules: 'qtcharts qtdatavis3d qtvirtualkeyboard qtwebengine qtquick3d qt3d qt5compat qtimageformats qtmultimedia qtwebview qtserialport qtshadertools qtquicktimeline qtwebsockets qtwebchannel qtpositioning'
-          - qt-version: '6.8.3'
-            qt-modules: 'qtcharts qtdatavis3d qtvirtualkeyboard qtwebengine qtquick3d qt3d qt5compat qtimageformats qtmultimedia qtwebview qtserialport qtshadertools qtquicktimeline qtwebsockets qtwebchannel qtpositioning'
           - qt-version: '6.9.1'
             qt-modules: 'qtcharts qtdatavis3d qtvirtualkeyboard qtwebengine qtquick3d qt3d qt5compat qtimageformats qtmultimedia qtwebview qtserialport qtshadertools qtquicktimeline qtwebsockets qtwebchannel qtpositioning'
           - qt-version: '6.10.1'
@@ -44,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: ${{ github.ref == 'refs/heads/main' }}
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/qt-linux-cmake:ubuntu20-qt${{ matrix.qt-version }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/qt-linux-cmake:ubuntu22-qt${{ matrix.qt-version }}
           build-args: |
             QT=${{ matrix.qt-version }}
             QT_MODULES=${{ matrix.qt-modules }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,4 +165,8 @@ RUN wget -O Eigen.zip https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.
     && cmake -B eigen-3.4.0/build -S eigen-3.4.0 \
     && cmake --build eigen-3.4.0/build --target install
 
+# Verify glibc compatibility with Qt tools
+# This will fail the build if Qt requires a newer glibc than the base image provides
+RUN /opt/qt/${QT}/gcc_64/libexec/qmlimportscanner -rootPath /tmp 2>&1 || { echo "ERROR: Qt tools require a newer glibc version than this Ubuntu provides"; exit 1; }
+
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 # Install Qt
-ARG QT=6.8.2
+ARG QT=6.10.1
 ARG QT_MODULES=''
 ARG QT_HOST=linux
 ARG QT_TARGET=desktop
@@ -56,7 +56,7 @@ RUN . /venv/bin/activate && \
 # Should be run:
 # docker run -it --rm -v $(pwd):/src/ -u $(id -u):$(id -g) --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined
 # linuxdeployqt require for the application to be built with the oldest still supported glibc version
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # Install Dependencies
 RUN apt update                                                               && \
     apt upgrade -y                                                           && \
-    apt -y install software-properties-common wget build-essential autoconf     \
+    apt -y install software-properties-common wget build-essential autoconf libtool \
     git fuse libgl1-mesa-dev psmisc libpq-dev libssl-dev openssl libffi-dev \
     zlib1g-dev libdbus-1-3 libpulse-mainloop-glib0 python3 python3-pip      \
     desktop-file-utils libxcb-icccm4 libxcb-image0 libxcb-keysyms1          \
@@ -149,7 +149,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libfontconfig1-dev
 
 # Install latest libusb
-RUN git clone -b v1.0.26 https://github.com/libusb/libusb \
+RUN git clone -b v1.0.29 https://github.com/libusb/libusb \
     && cd libusb \
     && ./bootstrap.sh \
     && ./configure \

--- a/Readme.md
+++ b/Readme.md
@@ -5,9 +5,11 @@
 
 Ready to use environment to compile application using Qt/CMake and deploy [AppImage](https://github.com/probonopd/linuxdeployqt).
 
-* Qt 5.15.2 & 6.6.2
+* Ubuntu 22.04
+* Qt 6.10.1
 * CMake 3.30.3
-* GCC 9
+* GCC 11
+* libusb 1.0.29
 * linuxdeployqt
 
 ## How to use


### PR DESCRIPTION
* The base image in `Dockerfile` and the Docker tags in `.github/workflows/main.yml` are updated from Ubuntu 20.04 to Ubuntu 22.04, ensuring compatibility with newer dependencies.
* The default Qt version in `Dockerfile` is updated from 6.8.2 to 6.10.1, and the build matrix in `.github/workflows/main.yml` now only includes Qt 6.9.1 and 6.10.1, dropping support for Qt 5.15.2, 6.6.2, 6.7.3, and 6.8.3.
* The default GCC version is updated from 9 to 11, as reflected in the documentation.
* The installed libusb version is updated from 1.0.26 to 1.0.29.

This solves (in ubuntu20-qt6.10.1):
```
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6QmlCompiler.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6QmlCompiler.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Qml.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Qml.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Qml.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Network.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Network.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Network.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Core.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Core.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Core.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Core.so.6)
/opt/qt/6.10.1/gcc_64/libexec/qmlimportscanner: /lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.13' not found (required by /opt/qt/6.10.1/gcc_64/libexec/../lib/libQt6Core.so.6)
CMake Error at /opt/qt/6.10.1/gcc_64/lib/cmake/Qt6Qml/Qt6QmlMacros.cmake:4569 (message):
  Failed to scan target Target for QML imports: 1
Call Stack (most recent call first):
  /opt/qt/6.10.1/gcc_64/lib/cmake/Qt6Qml/Qt6QmlMacros.cmake:4624 (_qt_internal_scan_qml_imports)
  /opt/qt/6.10.1/gcc_64/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:799 (qt6_import_qml_plugins)
  /opt/qt/6.10.1/gcc_64/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:799 (cmake_language)
  /opt/qt/6.10.1/gcc_64/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:877 (_qt_internal_finalize_executable)
  /opt/qt/6.10.1/gcc_64/lib/cmake/Qt6Core/Qt6CoreMacros.cmake:921:EVAL:1 (qt6_finalize_target)
```