### PR TITLE
➕ `libfbclient2` for qt6.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,8 @@ RUN apt update                                                               && 
     libgomp1                                                                \
     libomp-dev                                                              \
     ninja-build                                                             \
-    libmysqlclient-dev
+    libmysqlclient-dev                                                      \
+    libfbclient2
 
 # Build cool cmake version (ubuntu 16.04 comes with cmake 3.5)
 ARG CMAKE=3.30.3


### PR DESCRIPTION
Current error:

```
ERROR: ldd outputLine: "libfbclient.so.2 => not found"
ERROR: for binary:
"/opt/qt/6.10.1/gcc_64/plugins/sqldrivers/libqsqlibase.so"
ERROR: Please ensure that all libraries can be found by ldd. Aborting.
```
